### PR TITLE
docs: add note on ~ expansion for logging.file.name

### DIFF
--- a/src/configuration/README.md
+++ b/src/configuration/README.md
@@ -113,6 +113,8 @@ Name of the log file.
 
 Default to `komga.log`, in the current directory.
 
+Note that `~` is not expanded to your home directory/User profile.
+
 ## Sample Configuration File
 
 Here is a sample `application.yml` file in case you need to customize it. Keep only the lines you need.


### PR DESCRIPTION
Unlike other paths (like `komga.database-backup.path`), if you use `~` in the path it won't be expanded.

Since the behavior differs from the others paths, it's worth mentioning it to avoid surprising the user.

See https://github.com/gotson/komga/issues/203