### PR TITLE
add one click install for YunoHost

### DIFF
--- a/src/installation/README.md
+++ b/src/installation/README.md
@@ -12,3 +12,4 @@ You can install Komga using various methods.
 - [AUR - Arch User Repository](thirdparty.md#aur-arch-user-repository)
 - [Qnap](thirdparty.md#qnap)
 - [FreeNAS](thirdparty.md#freenas)
+- [YunoHost](thirdparty.md#yunohost)

--- a/src/installation/thirdparty.md
+++ b/src/installation/thirdparty.md
@@ -23,3 +23,7 @@ Komga is available as a [QPKG](https://www.qnapclub.eu/en/qpkg/853).
 ## FreeNAS
 
 There is a [tutorial](https://blog.tommyku.com/blog/deploying-komga-on-freenas-jail/) to install Komga on FreeNAS jail.
+
+## YunoHost
+
+[![Install Komga with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=komga)


### PR DESCRIPTION
I recently created a Yunohost package for komga, it is now passing all our tests. Thus, adding one click link to install directly