### PR TITLE
Add an installation guide for Paperback

### DIFF
--- a/src/.vuepress/config/sideBar.js
+++ b/src/.vuepress/config/sideBar.js
@@ -83,7 +83,7 @@ module.exports = {
                 '/guides/search',
                 '/guides/webreader',
                 '/guides/tachiyomi',
-				'/guides/paperback',
+                '/guides/paperback',
                 '/guides/opds',
                 '/guides/chunky',
                 '/guides/gdrive',

--- a/src/.vuepress/config/sideBar.js
+++ b/src/.vuepress/config/sideBar.js
@@ -83,6 +83,7 @@ module.exports = {
                 '/guides/search',
                 '/guides/webreader',
                 '/guides/tachiyomi',
+				'/guides/paperback',
                 '/guides/opds',
                 '/guides/chunky',
                 '/guides/gdrive',

--- a/src/README.md
+++ b/src/README.md
@@ -8,7 +8,7 @@ features:
 - title: Organize
   details: Organize your CBZ, CBR, PDF and EPUB files in different libraries and collections
 - title: Read
-  details: Use the integrated Webreader, the Tachiyomi extension, or any OPDS reader
+  details: Use the integrated Webreader, the Tachiyomi extension, any OPDS reader, or other integrations
 - title: Manage
   details: Edit metadata for your series and books
 footer: MIT Licensed

--- a/src/guides/paperback.md
+++ b/src/guides/paperback.md
@@ -1,0 +1,65 @@
+# Read with Paperback
+
+Komga has an extension for [Paperback](https://paperback.moe/), a free iOS and iPadOS reader.
+
+::: warning Warning
+Paperback requires iOS 13.4+ or iPadOS 13.4+.
+:::
+
+## Install and configure
+
+### Add the source repository
+On your device open [https://framboisepi.github.io/paperback-extensions/komga/](https://framboisepi.github.io/paperback-extensions/komga/) then press **Add to Paperback**.
+
+::: details Add the source repository manually
+If you prefer, it is also possible to add the repository manually:
+
+1. In the app, go to **Settings**, **External Sources** then press **Edit** on the top right hand corner.
+1. Press the top left hand corner **+** button to add a repository.
+1. Use the base url:
+   ```
+   https://framboisepi.github.io/paperback-extensions/komga/
+   ```
+:::
+
+### Install the source
+1. In the app **Settings**, **External Sources** windows, choose <code>Browse <span style="color: grey;">Lemon's Extensions - Komga</span></code>
+   > or `Browse ...` followed by the repository name you chose previously
+
+1. Install the source **Komga**
+
+### Configure the source
+1. In the app **Settings**, **External Sources**, press the Komga source
+1. Select **Server Settings** and set your:
+   * server url
+   * username
+   * password
+1. Press **Save** to exit
+
+::: tip Tip
+You can test your settings by opening **Try settings** bellow the Server Settings section
+:::
+
+---
+
+## Track read progress
+
+It is possible to sync read chapters from the app to the Komga server using an implicit tracker.
+
+### Add the tracker repository
+1. In the app, go to **Settings**, **External Trackers** then press **Edit** on the top right hand corner
+1. Press the top left hand corner **+** button to add a repository.
+1. Use the base url (you should not open this url):
+   ```
+   https://framboisepi.github.io/paperback-trackers/komga/
+   ```
+
+### Install the tracker
+1. In the app **Settings**, **External Trackers** windows, choose `Browse ...` for the repository you just added
+1. Install the tracker **Komga**
+
+When you read or mark as read a chapter in the app, it will now be marked as such on your Komga server.
+
+## Changelog and Compatibility
+
+Each version of the Komga extension need a specific version of the Komga server to work properly.


### PR DESCRIPTION
This pull request add a guide to use Komga with Paperback.

The repositories I used are mines. Komga is of course also available in the "main" repository: [extensions primary](https://github.com/Paperback-iOS/extensions-sources/tree/primary) but for legal reasons, you may prefer a link that only contains one source. I can of course change this if you prefer.

I will try to add some pictures when I will have access to my Komga instance.

If you want to, it could, for example, be possible to add Paperback next to the Tachiyomi sections:
 - on the [homepage](https://raw.githubusercontent.com/gotson/komga-website/master/src/README.md)
 - in the [contribution page](https://github.com/gotson/komga-website/tree/master/src/contribution) since the extension is open source

I don't know what you would prefer, on one hand that would let people know about the possibility to use Paperback with Komga on the other since the source is not "official" you may prefer to keep it to the installation guide.

If someone have any suggestions or ideas, I would be happy to add them to improve this guide.