### PR TITLE
Add Installation via Scoop for Windows

### DIFF
--- a/src/installation/README.md
+++ b/src/installation/README.md
@@ -10,6 +10,7 @@ You can install Komga using various methods.
 ### Third-party integrations
 
 - [Windows installer and updater](thirdparty.md#windows-installer-and-updater)
+- [Scoop (Windows)](thirdparty.md#scoop-windows)
 - [AUR - Arch User Repository](thirdparty.md#aur-arch-user-repository)
 - [Qnap](thirdparty.md#qnap)
 - [FreeNAS](thirdparty.md#freenas)

--- a/src/installation/thirdparty.md
+++ b/src/installation/thirdparty.md
@@ -14,22 +14,18 @@ Komga is available in [Scoop](https://github.com/ScoopInstaller/Scoop)'s [extras
 
 ### Installation
 
-#### 1. (Skip if Scoop is installed) Install Scoop
-Open Powershell and run `iwr -useb get.scoop.sh | iex`. If you got an error, run `Set-ExecutionPolicy RemoteSigned -scope CurrentUser`.
+You need Scoop to use this installation method. Instruction to install Scoop can be found [here](https://github.com/ScoopInstaller/Scoop#installation).
 
-#### 1.1 (Optional) Install aria2 for multi-connection download
-Run `scoop install aria2`.
-
-#### 2. (Skip if JDK is installed) Add java bucket
+#### 1. (Skip if JDK is installed) Add java bucket
 Run `scoop add bucket extras`.
 
-#### 3. (Skip if JDK is installed) Install JDK
+#### 2. (Skip if JDK is installed) Install JDK
 Run `scoop install java/temurin-lts-jdk`.
 
-#### 4. (Skip if extras bucket is added) Add extras bucket
+#### 3. (Skip if extras bucket is added) Add extras bucket
 Run `scoop add bucket extras`.
 
-#### 5. Install Komga
+#### 4. Install Komga
 Run `scoop install komga`.
 
 ### Manage

--- a/src/installation/thirdparty.md
+++ b/src/installation/thirdparty.md
@@ -8,6 +8,42 @@ Those methods are not officially supported, if you encounter installation issues
 
 A [Powershell script](https://github.com/losslesspng/SetUpKomgaJava) to get up and running with Komga.
 
+## Scoop (Windows)
+
+Komga is available in [Scoop](https://github.com/ScoopInstaller/Scoop)'s [extras](https://github.com/ScoopInstaller/Extras) bucket.
+
+### Installation
+
+#### 1. Install Scoop (Skip if Scoop is installed)
+Open Powershell and run `iwr -useb get.scoop.sh | iex`. If you got an error, run `Set-ExecutionPolicy RemoteSigned -scope CurrentUser`.
+
+#### 1.1 (Optional) Install aria2 for multi-connection download
+Run `scoop install aria2`.
+
+#### 2. Add java bucket (Skip if JDK is installed)
+Run `scoop add bucket extras`.
+
+#### 3. Install JDK (Skip if JDK is installed)
+Run `scoop install java/temurin-lts-jdk`.
+
+#### 3. Add extras bucket (Skip if extras bucket is added)
+Run `scoop add bucket extras`.
+
+#### 4. Install Komga
+Run `scoop install komga`.
+
+### Manage
+#### Run
+Run `komga`.
+
+Note: Default config dir is `%USERPROFILE%\scoop\apps\komga\current\config`
+
+#### Update
+Run `scoop update komga`.
+
+#### Uninstall
+Run `scoop uninstall komga`
+
 ## AUR - Arch User Repository
 
 Komga is available as an [AUR](https://aur.archlinux.org/packages/komga/) package.

--- a/src/installation/thirdparty.md
+++ b/src/installation/thirdparty.md
@@ -16,17 +16,11 @@ Komga is available in [Scoop](https://github.com/ScoopInstaller/Scoop)'s [extras
 
 You need Scoop to use this installation method. Instruction to install Scoop can be found [here](https://github.com/ScoopInstaller/Scoop#installation).
 
-#### 1. (Skip if JDK is installed) Add java bucket
-Run `scoop add bucket java`.
+#### 1. (Skip if JDK is installed) Install JDK
+Run `scoop add bucket java` and then run `scoop install java/temurin-lts-jdk`.
 
-#### 2. (Skip if JDK is installed) Install JDK
-Run `scoop install java/temurin-lts-jdk`.
-
-#### 3. (Skip if extras bucket is added) Add extras bucket
-Run `scoop add bucket extras`.
-
-#### 4. Install Komga
-Run `scoop install komga`.
+#### 2. Install Komga
+Run `scoop add bucket extras` and then run `scoop install komga`.
 
 ### Manage
 #### Run

--- a/src/installation/thirdparty.md
+++ b/src/installation/thirdparty.md
@@ -14,22 +14,22 @@ Komga is available in [Scoop](https://github.com/ScoopInstaller/Scoop)'s [extras
 
 ### Installation
 
-#### 1. Install Scoop (Skip if Scoop is installed)
+#### 1. (Skip if Scoop is installed) Install Scoop
 Open Powershell and run `iwr -useb get.scoop.sh | iex`. If you got an error, run `Set-ExecutionPolicy RemoteSigned -scope CurrentUser`.
 
 #### 1.1 (Optional) Install aria2 for multi-connection download
 Run `scoop install aria2`.
 
-#### 2. Add java bucket (Skip if JDK is installed)
+#### 2. (Skip if JDK is installed) Add java bucket
 Run `scoop add bucket extras`.
 
-#### 3. Install JDK (Skip if JDK is installed)
+#### 3. (Skip if JDK is installed) Install JDK
 Run `scoop install java/temurin-lts-jdk`.
 
-#### 3. Add extras bucket (Skip if extras bucket is added)
+#### 4. (Skip if extras bucket is added) Add extras bucket
 Run `scoop add bucket extras`.
 
-#### 4. Install Komga
+#### 5. Install Komga
 Run `scoop install komga`.
 
 ### Manage

--- a/src/installation/thirdparty.md
+++ b/src/installation/thirdparty.md
@@ -17,7 +17,7 @@ Komga is available in [Scoop](https://github.com/ScoopInstaller/Scoop)'s [extras
 You need Scoop to use this installation method. Instruction to install Scoop can be found [here](https://github.com/ScoopInstaller/Scoop#installation).
 
 #### 1. (Skip if JDK is installed) Add java bucket
-Run `scoop add bucket extras`.
+Run `scoop add bucket java`.
 
 #### 2. (Skip if JDK is installed) Install JDK
 Run `scoop install java/temurin-lts-jdk`.


### PR DESCRIPTION
Add Installation via Scoop for Windows

Let me know if the information needed to be reduced. It can be simple as run `scoop install komga` and run `komga` assuming scoop and JDK is installed.