### PR TITLE
Fixed an error in the Scoop command line

### DIFF
--- a/src/installation/thirdparty.md
+++ b/src/installation/thirdparty.md
@@ -17,10 +17,10 @@ Komga is available in [Scoop](https://github.com/ScoopInstaller/Scoop)'s [extras
 You need Scoop to use this installation method. Instruction to install Scoop can be found [here](https://github.com/ScoopInstaller/Scoop#installation).
 
 #### 1. (Skip if JDK is installed) Install JDK
-Run `scoop add bucket java` and then run `scoop install java/temurin-lts-jdk`.
+Run `scoop bucket add java` and then run `scoop install java/temurin-lts-jdk`.
 
 #### 2. Install Komga
-Run `scoop add bucket extras` and then run `scoop install komga`.
+Run `scoop bucket add extras` and then run `scoop install komga`.
 
 ### Manage
 #### Run


### PR DESCRIPTION
The commands to add buckets were not valid, “add” had to be after “bucket” to work.
Otherwise, Scoop returns an error. 

![image](https://user-images.githubusercontent.com/13944652/187480715-bffbfd78-681b-401b-9fc4-2ad0840d2135.png)


Here is the reference in the documentation: https://github.com/ScoopInstaller/scoop/wiki/Buckets