### PR TITLE
docs: update Chunky Comic Reader info

### DIFF
--- a/docs/guides/opds.md
+++ b/docs/guides/opds.md
@@ -15,8 +15,9 @@ Here is a list of reader applications that have been tested:
 | Android | [Librera](https://play.google.com/store/apps/details?id=com.foobnix.pdf.reader)                                      |                                            :heavy_check_mark:                                            |           No            |                            No                             |
 | Android | [PocketBook](https://play.google.com/store/apps/details?id=com.obreey.reader)                                        |                                         :x: Doesn't show CBR/CBZ                                         |           No            |                            No                             |
 | iOS     | [KyBook 3](http://kybook-reader.com/)                                                                                |                                            :heavy_check_mark:                                            |         **Yes**         |                            No                             |
-| iOS     | [Chunky Comic Reader](http://chunkyreader.com/)                                                                      |                                            :heavy_check_mark:                                            |           No            |                     **OPDS PSE 1.0**                      |
 | iOS     | [Panels](https://panels.app/)                                                                                        |                                            :heavy_check_mark:                                            | **Yes**<br/>*(v2.8.2+)* | **OPDS PSE 1.0** (v2.8.0+)<br/>**OPDS PSE 1.1** (v2.9.7+) |
+| iPadOS macOS    | [Chunky Comic Reader](https://apps.apple.com/us/app/chunky-comic-reader/id663567628)                                                                      |                                            :heavy_check_mark:                                            |           No            |                     **OPDS PSE 1.0**                      |
+
 
 The OPDS feed also supports:
 

--- a/docs/guides/opds.md
+++ b/docs/guides/opds.md
@@ -16,7 +16,7 @@ Here is a list of reader applications that have been tested:
 | Android | [PocketBook](https://play.google.com/store/apps/details?id=com.obreey.reader)                                        |                                         :x: Doesn't show CBR/CBZ                                         |           No            |                            No                             |
 | iOS     | [KyBook 3](http://kybook-reader.com/)                                                                                |                                            :heavy_check_mark:                                            |         **Yes**         |                            No                             |
 | iOS     | [Panels](https://panels.app/)                                                                                        |                                            :heavy_check_mark:                                            | **Yes**<br/>*(v2.8.2+)* | **OPDS PSE 1.0** (v2.8.0+)<br/>**OPDS PSE 1.1** (v2.9.7+) |
-| iPadOS macOS    | [Chunky Comic Reader](https://apps.apple.com/us/app/chunky-comic-reader/id663567628)                                                                      |                                            :heavy_check_mark:                                            |           No            |                     **OPDS PSE 1.0**                      |
+| iPadOS  | [Chunky Comic Reader](https://apps.apple.com/us/app/chunky-comic-reader/id663567628)                                 |                               :x: Does not work anymore with Komga 1.4.0+                                |           No            |                     **OPDS PSE 1.0**                      |
 
 
 The OPDS feed also supports:


### PR DESCRIPTION
Hi, i updated the info of Chunky Comic Reader, the old url does not exist, so the link now points to the app store.