### PR TITLE
Add HTTPS Notice for Komga Integration in Paperback

### DIFF
--- a/website/docs/guides/paperback.md
+++ b/website/docs/guides/paperback.md
@@ -35,7 +35,7 @@ If you prefer, it is also possible to add the repository manually:
 ### Configure the source
 1. In the app **Settings**, **External Sources**, press the `Paperback` source
 1. Select **Server Settings** and set your:
-   * server url
+   * server url (it must be **HTTPS**, as Apple blocks HTTP requests from apps)
    * username
    * password
 1. Press **Save** to exit


### PR DESCRIPTION
This PR adds a notice in the documentation regarding the requirement for using HTTPS when integrating Komga with Paperback.

Quite a few users in the Paperback Discord have reported issues when attempting to integrate Komga, and the reason was that they were using HTTP. 
Since Apple blocks HTTP requests from apps, this has been causing failed connections. To avoid further confusion, the documentation now highlights that HTTPS must be used for successful integration.