### PR TITLE
Fix typo in the podman guide

### DIFF
--- a/website/docs/installation/thirdparty/podman.md
+++ b/website/docs/installation/thirdparty/podman.md
@@ -155,7 +155,7 @@ These quadlet files were tested with podman version 4.5.3
 
 ## Parameters
 
-Refer to [Run with Docker](../docker.md#parameters) for information about parameters and lemory limit.
+Refer to [Run with Docker](../docker.md#parameters) for information about parameters and memory limit.
 
 ## Support info
 


### PR DESCRIPTION
Just fixing a small typo in the guide.