### PR TITLE
docs(installation): add community Helm chart option

### DIFF
--- a/website/docs/installation/thirdparty/helm.md
+++ b/website/docs/installation/thirdparty/helm.md
@@ -1,0 +1,37 @@
+# Run on Kubernetes with Helm
+
+:::warning
+This method is not officially supported.
+:::
+
+A community-maintained Helm chart for Komga is available from [HelmForge](https://github.com/helmforgedev/charts/tree/main/charts/komga).
+
+The chart is maintained outside of the Komga project. Issues and feature requests for the chart should be reported to the [HelmForge charts repository](https://github.com/helmforgedev/charts).
+
+## Install
+
+### From the Helm repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install komga helmforge/komga
+```
+
+### Via OCI
+
+```bash
+helm install komga oci://ghcr.io/helmforgedev/helm/komga
+```
+
+## Features
+
+- Persistent storage for Komga configuration and library data
+- Ingress, probes, security contexts, and service configuration
+- Komga-specific values for server and logging configuration
+- Optional S3-compatible backup support
+
+## Links
+
+- [HelmForge Komga chart source](https://github.com/helmforgedev/charts/tree/main/charts/komga)
+- [HelmForge Komga chart on ArtifactHub](https://artifacthub.io/packages/helm/helmforge/komga)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -49,6 +49,7 @@ const sidebars = {
                         type: 'generated-index',
                     },
                     items: [
+                        'installation/thirdparty/helm',
                         'installation/thirdparty/podman',
                         'installation/thirdparty/pikapods',
                         'installation/thirdparty/scoop',


### PR DESCRIPTION
## Summary
- add a new third-party installation page for running Komga on Kubernetes with Helm
- link to the community-maintained HelmForge Komga chart and ArtifactHub package
- register the new page in the Installation > Third-party methods sidebar

## Notes
- this documents a community-maintained option and keeps it clearly marked as unsupported by the Komga project
- closes gotson/komga#2268

## Validation
- npm install
- npm -w website run build
- local build required a temporary mock OpenAPI sidebar because this repository does not build cleanly on Windows without it; that temporary file was not committed