### PR TITLE
docs: add guide to read with Yomu

### DIFF
--- a/website/docs/guides/yomu.md
+++ b/website/docs/guides/yomu.md
@@ -1,14 +1,14 @@
 # Read with Yomu
 
-Komga is supported natively in [Yomu](https://yomureader.app/), a free manga, webtoon, and manhwa reader for iPhone, iPad, and Mac. No separate extension or repository to install — Komga support is built in.
+Komga is supported natively in [Yomu](https://yomureader.app/), a free manga, webtoon, and manhwa reader for iPhone, iPad, and Mac. No separate extension or repository to install, Komga support is built in.
 
-## Install and configure
+## Install and configure {#install}
 
 1. Download Yomu from the [App Store](https://apps.apple.com/app/yomu/id6760745234) (iOS, iPadOS, macOS).
 2. Open the app and tap **Browse** → tap the **+** button → choose **Add Komga Server**.
 3. Enter your server details:
-   - **Name** — optional label shown in the Browse list
-   - **Server URL** — e.g. `https://my.server:25600`
+   - **Name**: optional label shown in the Browse list
+   - **Server URL**: e.g. `https://my.server:25600`
    - **Username** and **Password**
 4. Tap **Test Connection** to verify, then **Save**.
 
@@ -16,36 +16,34 @@ Komga is supported natively in [Yomu](https://yomureader.app/), a free manga, we
 The server URL has no trailing slash. If you use a base URL path (e.g. `https://my.server/komga`) include it in the field.
 :::
 
-You can configure multiple Komga servers — each one appears as its own entry under Browse.
+You can configure multiple Komga servers, each one appears as its own entry under _Browse_.
 
-## Browse
+## Browse {#browse}
 
 Yomu lets you browse series, filter, and search across every Komga server you've added.
-
 - Browse popular and latest series
 - Search by title across the server
 - Filter by status, genre, or reading progress
 - Tap any series to see chapters and start reading
 
-## Read
+## Read {#read}
 
-The reader supports left-to-right (manga), right-to-left, and vertical / webtoon scroll modes — set per series. Pages download in the background for offline reading on the train, in the air, or anywhere without signal.
-
+The reader supports left-to-right (manga), right-to-left, and vertical / webtoon scroll modes, set per series. Pages download in the background for offline reading.
 - Single page, double page, or continuous scroll
 - Read-state syncs back to the Komga server automatically as you finish chapters
 - Bookmarks and per-series reader settings
 - External display support on iPad and Mac
 
-## Track read progress
+## Track read progress {#read-progress}
 
-Reading progress (last page read, completed chapters) syncs to your Komga server automatically — no extra setup. Open the same series on a different device or in the Komga web UI and it picks up where you left off.
+Reading progress (last page read, completed chapters) syncs to your Komga server automatically, no extra setup. Open the same series on a different device or in the Komga web UI and it picks up where you left off.
 
 You can also link series to AniList, MyAnimeList, Kitsu, or MangaUpdates for cross-service tracking.
 
-## Compatibility
+## Compatibility {#compatibility}
 
 For best results, keep both up to date:
 - Komga server (latest stable)
 - Yomu (latest from the App Store)
 
-Yomu uses the official Komga REST API (`/api/v1`) — no plugins or shims needed.
+Yomu uses the official Komga REST API, no plugins or shims needed.

--- a/website/docs/guides/yomu.md
+++ b/website/docs/guides/yomu.md
@@ -1,0 +1,51 @@
+# Read with Yomu
+
+Komga is supported natively in [Yomu](https://yomureader.app/), a free manga, webtoon, and manhwa reader for iPhone, iPad, and Mac. No separate extension or repository to install — Komga support is built in.
+
+## Install and configure
+
+1. Download Yomu from the [App Store](https://apps.apple.com/app/yomu/id6760745234) (iOS, iPadOS, macOS).
+2. Open the app and tap **Browse** → tap the **+** button → choose **Add Komga Server**.
+3. Enter your server details:
+   - **Name** — optional label shown in the Browse list
+   - **Server URL** — e.g. `https://my.server:25600`
+   - **Username** and **Password**
+4. Tap **Test Connection** to verify, then **Save**.
+
+:::tip
+The server URL has no trailing slash. If you use a base URL path (e.g. `https://my.server/komga`) include it in the field.
+:::
+
+You can configure multiple Komga servers — each one appears as its own entry under Browse.
+
+## Browse
+
+Yomu lets you browse series, filter, and search across every Komga server you've added.
+
+- Browse popular and latest series
+- Search by title across the server
+- Filter by status, genre, or reading progress
+- Tap any series to see chapters and start reading
+
+## Read
+
+The reader supports left-to-right (manga), right-to-left, and vertical / webtoon scroll modes — set per series. Pages download in the background for offline reading on the train, in the air, or anywhere without signal.
+
+- Single page, double page, or continuous scroll
+- Read-state syncs back to the Komga server automatically as you finish chapters
+- Bookmarks and per-series reader settings
+- External display support on iPad and Mac
+
+## Track read progress
+
+Reading progress (last page read, completed chapters) syncs to your Komga server automatically — no extra setup. Open the same series on a different device or in the Komga web UI and it picks up where you left off.
+
+You can also link series to AniList, MyAnimeList, Kitsu, or MangaUpdates for cross-service tracking.
+
+## Compatibility
+
+For best results, keep both up to date:
+- Komga server (latest stable)
+- Yomu (latest from the App Store)
+
+Yomu uses the official Komga REST API (`/api/v1`) — no plugins or shims needed.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -121,6 +121,7 @@ const sidebars = {
                         'guides/komic',
                         'guides/mangabox',
                         'guides/kmreader',
+                        'guides/yomu',
                         'guides/chunky',
                     ],
                 },


### PR DESCRIPTION
Adds a guide for [Yomu](https://yomureader.app/), a free native iOS / iPadOS / macOS Komga client.

Yomu has built-in Komga support (no separate extension or repository required) and uses the official Komga REST API. Listed alongside the existing third-party app guides (mihon, paperback, panels, chunky, etc.).

- App Store: https://apps.apple.com/app/yomu/id6760745234
- Website: https://yomureader.app