### PR TITLE
docs: add Hostim to third-party install options

### DIFF
--- a/website/docs/installation/thirdparty/hostim.md
+++ b/website/docs/installation/thirdparty/hostim.md
@@ -1,0 +1,7 @@
+# Run on Hostim
+
+:::warning
+This method is not officially supported.
+:::
+
+[Hostim.dev](https://hostim.dev) offers managed hosting for Komga with a one-click template, hosted in Germany (EU). See the [Komga template guide](https://hostim.dev/docs/templates/komga/) for deployment steps.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -58,6 +58,7 @@ const sidebars = {
                         'installation/thirdparty/truenas',
                         'installation/thirdparty/qnap',
                         'installation/thirdparty/aur',
+                        'installation/thirdparty/hostim',
                     ],
                 },
                 {


### PR DESCRIPTION
Adds a third-party installation entry for hostim.dev, following the
existing pattern (pikapods, freenas, etc.).

Hostim.dev is a hosting platform based in Germany (EU). Komga is
available as a one-click template:
https://hostim.dev/docs/templates/komga/

Single short markdown file + one line in sidebars.js.
