### PR TITLE
docs: added link in community apps for a Komga app for Homey

### DIFF
--- a/website/docs/community.md
+++ b/website/docs/community.md
@@ -25,3 +25,7 @@ This page lists community applications or tools that can be used alongside Komga
 ## CLU (Comic Library Utilities)
 
 > [CLU](https://phillips-organization-6.gitbook.io/clu-comic-library-utilities) is an all-in-one application to manage your comic, manga and magazine libraries.
+
+## Homey
+
+> [Homey](https://homey.app/en-us/app/net.ladenius.komga/Komga/) is a smart home platform, and has an [app to automate Komga](https://github.com/jurjen74/homey-komga).


### PR DESCRIPTION
I developed an app for Homey to monitor and automate Komga and show widgets in the Homey Dashboard.