### PR TITLE
docs: added link to community plugin for koreader

### DIFF
--- a/website/docs/guides/koreader.md
+++ b/website/docs/guides/koreader.md
@@ -74,3 +74,7 @@ If you use KOReader on a Kobo device, you can set up [Kobo Sync](kobo.mdx) and o
 ### ComicMeta {#comicmeta}
 
 [ComicMeta](https://korcomic.github.io/docs/comicmeta.koplugin/intro/): a plugin that extracts ComicInfo metadata from your comics.
+
+### Komga Bulk Downloader {#komgadownloader}
+
+[Komga Bulk Downloader](https://akamuraasai.github.io/koreader-komga/): a plugin that allows you to download chapters in bulk, making it easier to have your chapters offline.

--- a/website/docs/guides/koreader.md
+++ b/website/docs/guides/koreader.md
@@ -77,4 +77,4 @@ If you use KOReader on a Kobo device, you can set up [Kobo Sync](kobo.mdx) and o
 
 ### Komga Bulk Downloader {#komgadownloader}
 
-[Komga Bulk Downloader](https://akamuraasai.github.io/koreader-komga/): a plugin that allows you to download chapters in bulk, making it easier to have your chapters offline.
+[Komga Bulk Downloader](https://akamuraasai.github.io/koreader-komga/): a plugin that allows you to download books in bulk, making it easier to have your books offline.


### PR DESCRIPTION
This PR adds an entry in the KOReader documentation about a plugin that allows for bulk chapter downloads.
Making it easier to read them on the device (instead of using OPDS).