### PR TITLE
Add cbzit to Community page

### DIFF
--- a/website/docs/community.md
+++ b/website/docs/community.md
@@ -29,3 +29,7 @@ This page lists community applications or tools that can be used alongside Komga
 ## Homey
 
 > [Homey](https://homey.app/en-us/app/net.ladenius.komga/Komga/) is a smart home platform, and has an [app to automate Komga](https://github.com/jurjen74/homey-komga).
+
+## cbzit
+
+> [cbzit](https://github.com/mate2/cbzit) is a command-line tool that turns folders of manga/comic page images into cleanly-named `.cbz` archives — smart structure detection, a dry-run report before it writes anything, and a `merge` command to consolidate chapter archives into per-volume ones. Your original files are never touched.


### PR DESCRIPTION
Adds **cbzit** to the Community page.

[cbzit](https://github.com/mate2/cbzit) is an open-source (MIT) command-line tool that turns folders of manga/comic page images into cleanly-named `.cbz` archives — the step before Komga picks them up. It detects the structure (series / volumes / chapters / language) bottom-up, prints a dry-run report before writing anything, and never touches the original files. It also has a `merge` subcommand to consolidate chapter `.cbz` files into per-volume archives.

Single entry appended at the end of the list, following the existing blockquote style.